### PR TITLE
Add Google Translate translation service helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@google-cloud/translate": "^8.4.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -29,6 +30,12 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@google-cloud/translate": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-8.4.0.tgz",
+      "integrity": "",
+      "license": "Apache-2.0"
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
+    "@google-cloud/translate": "^8.4.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/utils/translationService.js
+++ b/utils/translationService.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Google Cloud Translate service helper.
+ *
+ * NOTE: Never commit service account JSON keys to the repository. Store the
+ * credential file outside of git and expose its absolute path via the
+ * GOOGLE_APPLICATION_CREDENTIALS environment variable.
+ */
+const {TranslationServiceClient} = require('@google-cloud/translate').v3;
+
+const clientOptions = {};
+const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+if (credentialsPath) {
+  clientOptions.keyFilename = credentialsPath;
+}
+
+let translationClient;
+
+function getProjectId() {
+  const projectId = process.env.GOOGLE_TRANSLATE_PROJECT_ID;
+  if (!projectId) {
+    throw new Error('GOOGLE_TRANSLATE_PROJECT_ID environment variable is required');
+  }
+
+  return projectId;
+}
+
+function getClient() {
+  if (!translationClient) {
+    translationClient = new TranslationServiceClient(clientOptions);
+  }
+
+  return translationClient;
+}
+
+const MAX_RETRY_ATTEMPTS = 3;
+const INITIAL_BACKOFF_MS = 500;
+const SUPPORTED_FIELDS = ['title', 'description', 'requirements'];
+
+function sleep(duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+function getLocation() {
+  return process.env.GOOGLE_TRANSLATE_LOCATION || 'global';
+}
+
+function getParent() {
+  return `projects/${getProjectId()}/locations/${getLocation()}`;
+}
+
+async function translateTextWithRetry(text, sourceLang, targetLang) {
+  let attempt = 0;
+  let delay = INITIAL_BACKOFF_MS;
+
+  while (attempt < MAX_RETRY_ATTEMPTS) {
+    try {
+      const request = {
+        parent: getParent(),
+        contents: [text ?? ''],
+        mimeType: 'text/plain',
+        targetLanguageCode: targetLang,
+      };
+
+      if (sourceLang) {
+        request.sourceLanguageCode = sourceLang;
+      }
+
+      const [response] = await getClient().translateText(request);
+      const [translation] = response.translations || [];
+      return translation?.translatedText ?? '';
+    } catch (error) {
+      attempt += 1;
+      console.error(
+        `Translation API request failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}):`,
+        error
+      );
+
+      if (attempt >= MAX_RETRY_ATTEMPTS) {
+        throw error;
+      }
+
+      await sleep(delay);
+      delay *= 2;
+    }
+  }
+
+  return '';
+}
+
+async function translateFields({fields = {}, sourceLang, targetLang}) {
+  if (!targetLang) {
+    throw new Error('targetLang is required');
+  }
+
+  const result = {};
+  for (const key of SUPPORTED_FIELDS) {
+    const value = fields[key];
+    if (value === undefined || value === null) {
+      result[key] = value;
+      continue;
+    }
+
+    if (value === '') {
+      result[key] = '';
+      continue;
+    }
+
+    if (typeof value !== 'string') {
+      result[key] = value;
+      continue;
+    }
+
+    result[key] = await translateTextWithRetry(value, sourceLang, targetLang);
+  }
+
+  return result;
+}
+
+module.exports = {
+  translateFields,
+};


### PR DESCRIPTION
## Summary
- add the official `@google-cloud/translate` dependency to the project configuration
- create a translation service helper that wires the Translation API v3 client and exposes a `translateFields` utility with retry logging
- document environment-driven credential handling so JSON keys stay outside the repository

## Testing
- not run (network access is restricted in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9aee059d483328486a49e63a46873