### PR TITLE
Add job post translation cache support

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -87,6 +87,7 @@ const initializeDatabase = async () => {
       "companies",
       "hr_profiles",
       "job_posts",
+      "job_post_translations",
       "applications",
       "bookmarks",
       "certificates",
@@ -145,6 +146,17 @@ const initializeDatabase = async () => {
         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         INDEX idx_admin_logs_created (created_at),
         CONSTRAINT fk_admin_logs_admin FOREIGN KEY (admin_id) REFERENCES users(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+    `);
+
+    await pool.execute(`
+      CREATE TABLE IF NOT EXISTS job_post_translations (
+        job_id INT NOT NULL,
+        language_code VARCHAR(16) NOT NULL,
+        translation_data LONGTEXT NULL,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (job_id, language_code),
+        CONSTRAINT fk_job_post_translations_job FOREIGN KEY (job_id) REFERENCES job_posts(id) ON DELETE CASCADE
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
     `);
 

--- a/controllers/jobController.js
+++ b/controllers/jobController.js
@@ -365,6 +365,7 @@ exports.updateJob = async (req, res) => {
 exports.deleteJob = async (req, res) => {
   try {
     const { id } = req.params;
+    await db.query("DELETE FROM job_post_translations WHERE job_id = ?", [id]);
     await db.query("DELETE FROM job_posts WHERE id = ?", [id]);
     res.json({ success: true, message: "Job deleted" });
   } catch (err) {

--- a/utils/translationService.js
+++ b/utils/translationService.js
@@ -1,0 +1,82 @@
+const { db } = require("../config/database");
+
+const CACHE_TTL_DAYS = 7;
+const CACHE_TTL_MS = CACHE_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+const isFresh = (updatedAt) => {
+  if (!updatedAt) return false;
+  const updatedTime = new Date(updatedAt).getTime();
+  return Number.isFinite(updatedTime) && Date.now() - updatedTime < CACHE_TTL_MS;
+};
+
+const parseTranslation = (row) => {
+  if (!row) return null;
+  if (!row.translation_data) return null;
+
+  try {
+    return JSON.parse(row.translation_data);
+  } catch (error) {
+    console.warn("⚠️  Failed to parse translation cache, ignoring", error);
+    return null;
+  }
+};
+
+const getTranslationRow = async (jobId, languageCode) => {
+  const [rows] = await db.query(
+    `SELECT job_id, language_code, translation_data, updated_at
+     FROM job_post_translations
+     WHERE job_id = ? AND language_code = ?
+     LIMIT 1`,
+    [jobId, languageCode]
+  );
+
+  return rows?.[0] ?? null;
+};
+
+const saveTranslation = async (jobId, languageCode, translation) => {
+  const payload = translation ? JSON.stringify(translation) : null;
+
+  await db.query(
+    `INSERT INTO job_post_translations (job_id, language_code, translation_data, updated_at)
+     VALUES (?, ?, ?, NOW())
+     ON DUPLICATE KEY UPDATE
+       translation_data = VALUES(translation_data),
+       updated_at = VALUES(updated_at)`,
+    [jobId, languageCode, payload]
+  );
+
+  return translation;
+};
+
+const getCachedTranslation = async (jobId, languageCode) => {
+  const row = await getTranslationRow(jobId, languageCode);
+  if (row && isFresh(row.updated_at)) {
+    return parseTranslation(row);
+  }
+  return null;
+};
+
+const getTranslationWithFallback = async (jobId, languageCode, fetchFn) => {
+  if (typeof fetchFn !== "function") {
+    throw new TypeError("fetchFn must be a function that returns translation data");
+  }
+
+  const row = await getTranslationRow(jobId, languageCode);
+  const cached = row && isFresh(row.updated_at) ? parseTranslation(row) : null;
+  if (cached) {
+    return cached;
+  }
+
+  const freshData = await fetchFn();
+  if (freshData !== undefined) {
+    await saveTranslation(jobId, languageCode, freshData);
+  }
+
+  return freshData ?? null;
+};
+
+module.exports = {
+  getCachedTranslation,
+  getTranslationWithFallback,
+  saveTranslation,
+};


### PR DESCRIPTION
## Summary
- create the job_post_translations table during database bootstrap with a composite primary key
- add a reusable translation cache helper for job post translations backed by MySQL
- remove translation cache rows when deleting job posts to avoid orphan data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9b2d51a9083328bfbe10ea5e55641