### PR TITLE
Document translation configuration and lang query usage

### DIFF
--- a/docs/STTI_Career_API.md
+++ b/docs/STTI_Career_API.md
@@ -82,6 +82,34 @@ Respon singkat:
 
 **Public**
 - **GET** `/` → list lowongan (urutan terbaru).
+  - Query opsional `lang`:
+    - `lang=id` (default) → kirim teks asli dari database (umumnya Bahasa Indonesia).
+    - `lang=en` → paksa judul & deskripsi diterjemahkan ke Inggris. Respons juga menambahkan objek `translations`.
+    - `lang=all` → kirim teks asli + seluruh hasil terjemahan yang tersedia (`translations.id`, `translations.en`, dst.).
+  - Contoh respons `lang=all`:
+    ```json
+    {
+      "success": true,
+      "data": [
+        {
+          "id": 101,
+          "job_title": "Backend Engineer",
+          "job_description": "Bangun API dengan Node.js",
+          "translations": {
+            "id": {
+              "job_title": "Backend Engineer",
+              "job_description": "Bangun API dengan Node.js"
+            },
+            "en": {
+              "job_title": "Backend Engineer",
+              "job_description": "Build APIs with Node.js"
+            }
+          }
+        }
+      ]
+    }
+    ```
+- Catatan fallback: bila layanan Google Translate gagal/timeout, API tetap mengembalikan teks asli (tanpa mengosongkan field) dan `translations` hanya berisi bahasa yang berhasil (atau di-skip sama sekali). QA bisa mengecek log server untuk detail error.
 - **GET** `/loker/summary` → kolom ringkas: `id`, `job_title`, `is_active`, `verification_status`, `created_at`.
 - **GET** `/details/:id` → detail + `total_applications` + `selection_stages` (jika ada).
 - **GET** `/:id` → detail 1 lowongan.

--- a/postman/STTI_Career_API.postman_collection.json
+++ b/postman/STTI_Career_API.postman_collection.json
@@ -598,6 +598,24 @@
           }
         },
         {
+          "name": "List publik (lang=en)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/jobs?lang=en"
+          },
+          "description": "Gunakan query `lang=en` untuk memaksa terjemahan Inggris pada judul/deskripsi job. Field `translations.en` akan terisi."
+        },
+        {
+          "name": "List publik (lang=all)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/jobs?lang=all"
+          },
+          "description": "Mengembalikan bahasa asli + objek `translations` berisi semua bahasa yang tersedia (mis. `id`, `en`)."
+        },
+        {
           "name": "Summary publik",
           "request": {
             "method": "GET",

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,13 @@ cp .env.example .env
 # PORT=5000
 # JWT_SECRET=ganti-ini-dengan-string-acak-panjang
 # JWT_EXPIRES_IN=1h
+# GOOGLE_TRANSLATE_PROJECT_ID=<project-id-google-cloud>
+# GOOGLE_TRANSLATE_LOCATION=global   # atau lokasi region yang kamu pakai
+# GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/ke/google-translate-key.json
+#
+# Simpan file kredensial Google Cloud (JSON) **di luar repository** agar tidak
+# ikut ter-commit. Contoh aman di lokal: `~/secrets/stti-google-key.json`, lalu
+# arahkan `GOOGLE_APPLICATION_CREDENTIALS` ke path tersebut.
 
 # 3) Start server
 npm run start


### PR DESCRIPTION
## Summary
- document the Google Translate environment variables in the README with guidance on storing the service account key outside the repo
- expand the jobs endpoint docs to explain the `lang` query parameter, the `translations` shape, and fallback behavior when translation fails
- add ready-to-run Postman examples for `/api/jobs?lang=en` and `/api/jobs?lang=all`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b3c776a4833297094f9670488db5