### PR TITLE
Add translate dependency to lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "mysql2": "^3.6.0",
-        "path": "^0.12.7"
+        "path": "^0.12.7",
+        "@google-cloud/translate": "^8.0.3"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"


### PR DESCRIPTION
## Summary
- add the `@google-cloud/translate` package to the root dependency map in `package-lock.json`

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden when retrieving @google-cloud/translate from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9be070e788332ad84a5be91cb70b3